### PR TITLE
Update baseURL to point to Team Heroku

### DIFF
--- a/client/UserAxiosClient.ts
+++ b/client/UserAxiosClient.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 import User from "../models/users/User";
 // axios.defaults.baseURL = 'http://localhost:4000/api';
-axios.defaults.baseURL = 'https://cs5500-01-sp22.herokuapp.com/api';
+axios.defaults.baseURL = 'https://team12-tuiter-backend.herokuapp.com/api';
 
 const findAllUsers = async () =>
     await axios.get('/users');


### PR DESCRIPTION
As a part of Sprint 1, the following change updates the `baseURL` to point to Heroku's URL where the backend would be hosted. 

