### PR TITLE
[2] Admin deletes a user

### DIFF
--- a/controllers/AdminController.ts
+++ b/controllers/AdminController.ts
@@ -36,6 +36,8 @@ export default class AdminController implements AdminControllerI {
             // RESTful User Web service API
             app.get("/admin/api/users",
                 AdminController.adminController.findAllUsers); 
+            app.post("/admin/api/users",
+                AdminController.adminController.createUser);
         }
         return AdminController.adminController;
     }
@@ -51,4 +53,17 @@ export default class AdminController implements AdminControllerI {
     findAllUsers = (req: Request, res: Response) =>
         AdminController.adminDao.findAllUsers()
             .then((users: User[]) => res.json(users));
+
+    /**
+     * Creates a new user instance
+     * @param {Request} req Represents request from client, including body
+     * containing the JSON object for the new user to be inserted in the
+     * database
+     * @param {Response} res Represents response to client, including the
+     * body formatted as JSON containing the new user that was inserted in the
+     * database
+     */
+     createUser = (req: Request, res: Response) =>
+        AdminController.adminDao.createUser(req.body)
+            .then((user: User) => res.json(user));
 };

--- a/controllers/AdminController.ts
+++ b/controllers/AdminController.ts
@@ -38,6 +38,8 @@ export default class AdminController implements AdminControllerI {
                 AdminController.adminController.findAllUsers); 
             app.post("/admin/api/users",
                 AdminController.adminController.createUser);
+            app.delete("/admin/api/users/:uid",
+                AdminController.adminController.deleteUser);
         }
         return AdminController.adminController;
     }
@@ -66,4 +68,16 @@ export default class AdminController implements AdminControllerI {
      createUser = (req: Request, res: Response) =>
         AdminController.adminDao.createUser(req.body)
             .then((user: User) => res.json(user));
+
+
+    /**
+     * Removes a user instance from the database
+     * @param {Request} req Represents request from client, including path
+     * parameter uid identifying the primary key of the user to be removed
+     * @param {Response} res Represents response to client, including status
+     * on whether deleting a user was successful or not
+     */
+     deleteUser = (req: Request, res: Response) =>
+        AdminController.adminDao.deleteUser(req.params.uid)
+            .then((status) => res.send(status));
 };

--- a/daos/AdminDao.ts
+++ b/daos/AdminDao.ts
@@ -37,4 +37,12 @@ export default class AdminDao implements AdminDaoI {
     findAllUsers = async (): Promise<User[]> =>
         UserModel.find().exec();
 
+    /**
+     * Inserts user instance into the database
+     * @param {User} user Instance to be inserted into the database
+     * @returns Promise To be notified when user is inserted into the database
+     */
+    createUser = async (user: User): Promise<User> =>
+        UserModel.create(user);
+
 };

--- a/daos/AdminDao.ts
+++ b/daos/AdminDao.ts
@@ -45,4 +45,12 @@ export default class AdminDao implements AdminDaoI {
     createUser = async (user: User): Promise<User> =>
         UserModel.create(user);
 
+    /**
+     * Removes user from the database.
+     * @param {string} uid Primary key of user to be removed
+     * @returns Promise To be notified when user is removed from the database
+     */
+    deleteUser = async (uid: string): Promise<any> =>
+        UserModel.deleteOne({_id: uid});
+
 };

--- a/interfaces/AdminControllerI.ts
+++ b/interfaces/AdminControllerI.ts
@@ -3,4 +3,5 @@ import {Request, Response} from "express";
 export default interface AdminControllerI {
     findAllUsers(req: Request, res: Response): void;
     createUser (req: Request, res: Response): void;
+    deleteUser (req: Request, res: Response): void;
 };

--- a/interfaces/AdminControllerI.ts
+++ b/interfaces/AdminControllerI.ts
@@ -2,4 +2,5 @@ import {Request, Response} from "express";
 
 export default interface AdminControllerI {
     findAllUsers(req: Request, res: Response): void;
+    createUser (req: Request, res: Response): void;
 };

--- a/interfaces/AdminDaoI.ts
+++ b/interfaces/AdminDaoI.ts
@@ -2,4 +2,5 @@ import User from "../models/users/User";
 
 export default interface AdminDaoI {
     findAllUsers(): Promise<User[]>;
+    createUser (user: User): Promise<User>;
 };

--- a/interfaces/AdminDaoI.ts
+++ b/interfaces/AdminDaoI.ts
@@ -3,4 +3,5 @@ import User from "../models/users/User";
 export default interface AdminDaoI {
     findAllUsers(): Promise<User[]>;
     createUser (user: User): Promise<User>;
+    deleteUser (uid: string): Promise<any>;
 };


### PR DESCRIPTION
Aim - The following PR adds the ability for an Admin to delete a user.

Idea - Similar to deleting a user from the database, an Admin should have the ability to remove a user from Tuiter.

Test - A **DELETE** request to `admin/api/users/:uid` where `uid` would be the user_id to be removed.

Changes made to these section of files -
AdminController
AdminDao